### PR TITLE
Vertex reordering

### DIFF
--- a/BasicRenderer/include/DX12Renderer.h
+++ b/BasicRenderer/include/DX12Renderer.h
@@ -122,6 +122,7 @@ private:
     void CreateRenderGraph();
     void SetSettings();
     void SetEnvironmentInternal(std::wstring name);
+	void ToggleMeshShaders(bool useMeshShaders);
 
     void WaitForFrame(uint8_t frameIndex);
     void SignalFence(ComPtr<ID3D12CommandQueue> commandQueue, uint8_t currentFrameIndex);

--- a/BasicRenderer/include/Managers/MeshManager.h
+++ b/BasicRenderer/include/Managers/MeshManager.h
@@ -19,8 +19,8 @@ public:
 	static std::unique_ptr<MeshManager> CreateUnique() {
 		return std::unique_ptr<MeshManager>(new MeshManager());
 	}
-	void AddMesh(std::shared_ptr<Mesh>& mesh, MaterialBuckets bucket);
-	void AddMeshInstance(MeshInstance* mesh);
+	void AddMesh(std::shared_ptr<Mesh>& mesh, MaterialBuckets bucket, bool useMeshletReorderedVertices);
+	void AddMeshInstance(MeshInstance* mesh, bool useMeshletReorderedVertices);
 	void RemoveMesh(Mesh* mesh);
 	void RemoveMeshInstance(MeshInstance* mesh);
 

--- a/BasicRenderer/include/Managers/ObjectManager.h
+++ b/BasicRenderer/include/Managers/ObjectManager.h
@@ -19,7 +19,7 @@ public:
 	static std::unique_ptr<ObjectManager> CreateUnique() {
 		return std::unique_ptr<ObjectManager>(new ObjectManager());
 	}
-	Components::ObjectDrawInfo AddObject(PerObjectCB& perObjectCB, const Components::OpaqueMeshInstances* opaqueInstances, const Components::AlphaTestMeshInstances* alphaTestInstances, const Components::BlendMeshInstances* blendInstances);
+	Components::ObjectDrawInfo AddObject(const PerObjectCB& perObjectCB, const Components::OpaqueMeshInstances* opaqueInstances, const Components::AlphaTestMeshInstances* alphaTestInstances, const Components::BlendMeshInstances* blendInstances);
 	void RemoveObject(const Components::ObjectDrawInfo* drawInfo);
 	void UpdatePerObjectBuffer(BufferView*, PerObjectCB& data);
 	void UpdateNormalMatrixBuffer(BufferView* view, void* data);

--- a/BasicRenderer/include/Mesh/Mesh.h
+++ b/BasicRenderer/include/Mesh/Mesh.h
@@ -92,6 +92,8 @@ public:
 		return m_skinningVertexSize;
 	}
 
+	void UpdateVertexCount(bool meshletReorderedVertices);
+
 private:
     Mesh(std::unique_ptr<std::vector<std::byte>> vertices, unsigned int vertexSize, std::optional<std::unique_ptr<std::vector<std::byte>>> skinningVertices, unsigned int skinningVertexSize, const std::vector<UINT32>& indices, const std::shared_ptr<Material>, unsigned int flags);
     void CreateVertexBuffer();

--- a/BasicRenderer/include/Mesh/MeshInstance.h
+++ b/BasicRenderer/include/Mesh/MeshInstance.h
@@ -16,6 +16,7 @@ public:
 
     //void SetPostSkinningVertexBufferView(std::unique_ptr<BufferView> view);
     BufferView* GetPostSkinningVertexBufferView();
+	BufferView* GetPerMeshInstanceBufferView() { return m_perMeshInstanceBufferView.get(); }
 
 	void SetBufferViews(std::unique_ptr<BufferView> postSkinningVertexBufferView, std::unique_ptr<BufferView> perMeshInstanceBufferView);
     void SetBufferViewUsingBaseMesh(std::unique_ptr<BufferView> perMeshInstanceBufferView);

--- a/BasicRenderer/include/Scene/Scene.h
+++ b/BasicRenderer/include/Scene/Scene.h
@@ -64,6 +64,7 @@ private:
     std::function<void(std::vector<float>)> setDirectionalLightCascadeSplits;
     std::function<uint8_t()> getNumDirectionalLightCascades;
     std::function<float()> getMaxShadowDistance;
+	std::function<bool()> getMeshShadersEnabled;
 
     void MakeResident();
 	void MakeNonResident();

--- a/BasicRenderer/include/ShaderBuffers.h
+++ b/BasicRenderer/include/ShaderBuffers.h
@@ -217,3 +217,8 @@ enum LightClusterRootConstants {
     LightPagesPoolSize,
 	NumLightClusterRootConstants
 };
+
+enum MiscRootConstants { // Used for pass-specific one-off constants
+	UintRootConstant0,
+	NumMiscRootConstants
+};

--- a/BasicRenderer/shaders/cbuffers.hlsli
+++ b/BasicRenderer/shaders/cbuffers.hlsli
@@ -56,4 +56,8 @@ cbuffer LightClusterInfo : register(b8) {
     uint lightPagesPoolSize;
 }
 
+cbuffer MiscRootConstants : register(b9) { // Used for pass-specific one-off constants
+    uint UintRootConstant0;
+}
+
 #endif // __CBUFFERS_HLSL__

--- a/BasicRenderer/shaders/mesh.hlsl
+++ b/BasicRenderer/shaders/mesh.hlsl
@@ -164,7 +164,7 @@ void MSMain(
 
     uint3 meshletIndices = uint3(b0, b1, b2);
     
-    uint vertOffset = meshlet.VertOffset + meshBuffer.meshletVerticesBufferOffset;
+    uint vertOffset = meshlet.VertOffset;
     
     if (uGroupThreadID < meshlet.VertCount) {
         //uint thisVertex = meshletVerticesBuffer[vertOffset + uGroupThreadID];

--- a/BasicRenderer/shaders/mesh.hlsl
+++ b/BasicRenderer/shaders/mesh.hlsl
@@ -167,8 +167,8 @@ void MSMain(
     uint vertOffset = meshlet.VertOffset + meshBuffer.meshletVerticesBufferOffset;
     
     if (uGroupThreadID < meshlet.VertCount) {
-        uint thisVertex = meshletVerticesBuffer[vertOffset + uGroupThreadID];
-        outputVertices[uGroupThreadID] = GetVertexAttributes(vertexBuffer, meshInstanceBuffer.postSkinningVertexBufferOffset, thisVertex, meshBuffer.vertexFlags, meshBuffer.vertexByteSize, vGroupID, objectBuffer);
+        //uint thisVertex = meshletVerticesBuffer[vertOffset + uGroupThreadID];
+        outputVertices[uGroupThreadID] = GetVertexAttributes(vertexBuffer, meshInstanceBuffer.postSkinningVertexBufferOffset, vertOffset + uGroupThreadID, meshBuffer.vertexFlags, meshBuffer.vertexByteSize, vGroupID, objectBuffer);
     }
     if (uGroupThreadID < meshlet.TriCount) {
         outputTriangles[uGroupThreadID] = meshletIndices;

--- a/BasicRenderer/shaders/skinning.hlsl
+++ b/BasicRenderer/shaders/skinning.hlsl
@@ -3,13 +3,13 @@
 #include "cbuffers.hlsli"
 
 [numthreads(64, 1, 1)]
-void CSMain(uint dispatchID : SV_DispatchThreadID) {
+void CSMain(uint3 dtid : SV_DispatchThreadID) {
     StructuredBuffer<PerMeshBuffer> perMeshBuffer = ResourceDescriptorHeap[perMeshBufferDescriptorIndex];
     PerMeshBuffer meshBuffer = perMeshBuffer[perMeshBufferIndex];
     StructuredBuffer<PerMeshInstanceBuffer> perMeshInstanceBuffer = ResourceDescriptorHeap[perMeshInstanceBufferDescriptorIndex];
     PerMeshInstanceBuffer meshInstanceBuffer = perMeshInstanceBuffer[perMeshInstanceBufferIndex];
-    
-    if (dispatchID >= meshBuffer.numVertices) {
+    uint vertexOffsetInMesh = dtid.x;
+    if (vertexOffsetInMesh >= meshBuffer.numVertices) {
         return;
     }
     
@@ -21,8 +21,8 @@ void CSMain(uint dispatchID : SV_DispatchThreadID) {
     
     StructuredBuffer<float4x4> normalMatrixBuffer = ResourceDescriptorHeap[normalMatrixBufferDescriptorIndex];
     
-    uint preSkinnedByteOffset = meshBuffer.vertexBufferOffset + dispatchID * meshBuffer.skinningVertexByteSize;
-    uint postSkinnedByteOffset = meshInstanceBuffer.postSkinningVertexBufferOffset + dispatchID * meshBuffer.vertexByteSize;
+    uint preSkinnedByteOffset = meshBuffer.vertexBufferOffset + vertexOffsetInMesh * meshBuffer.skinningVertexByteSize;
+    uint postSkinnedByteOffset = meshInstanceBuffer.postSkinningVertexBufferOffset + vertexOffsetInMesh * meshBuffer.vertexByteSize;
     
     Vertex input = LoadSkinningVertex(preSkinnedByteOffset, preSkinningVertexBuffer, meshBuffer.vertexFlags);
     

--- a/BasicRenderer/src/BasicRenderer.cpp
+++ b/BasicRenderer/src/BasicRenderer.cpp
@@ -325,14 +325,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     renderer.SetCurrentScene(baseScene);
     //mountainScene->AppendScene(dragonScene->Clone());
     renderer.GetCurrentScene()->AppendScene(dragonScene->Clone());
-	//renderer.GetCurrentScene()->AppendScene(mountainScene->Clone());
-	//renderer.GetCurrentScene()->AppendScene(cubeScene->Clone());
+	renderer.GetCurrentScene()->AppendScene(mountainScene->Clone());
+	renderer.GetCurrentScene()->AppendScene(cubeScene->Clone());
     //renderer.GetCurrentScene()->AppendScene(*tigerScene);
 
     //auto root = renderer.GetCurrentScene()->AppendScene(dragonScene->Clone());
 	//root.set<Components::Position>({ 0.0, 3.0, 0.0 });
     
-	for (int i = 0; i < 0; i++) {
+	for (int i = 0; i < 1; i++) {
 		float animationSpeed = randomFloat(0.5, 2.0);
    //     for (auto& object : tigerScene->GetOpaqueRenderableObjectIDMap()) {
 			//object.second->SetAnimationSpeed(animationSpeed);
@@ -343,7 +343,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	}
 
     //renderer.GetCurrentScene()->AppendScene(phoenixScene->Clone());
-    //auto root = renderer.GetCurrentScene()->AppendScene(carScene->Clone());
+    auto root = renderer.GetCurrentScene()->AppendScene(carScene->Clone());
     //renderer.GetCurrentScene()->RemoveEntityByID(root->GetLocalID(), true);
     //renderer.GetCurrentScene()->AppendScene(*cubeScene);
 	//renderer.GetCurrentScene()->AppendScene(bistro);

--- a/BasicRenderer/src/BasicRenderer.cpp
+++ b/BasicRenderer/src/BasicRenderer.cpp
@@ -325,14 +325,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     renderer.SetCurrentScene(baseScene);
     //mountainScene->AppendScene(dragonScene->Clone());
     renderer.GetCurrentScene()->AppendScene(dragonScene->Clone());
-	renderer.GetCurrentScene()->AppendScene(mountainScene->Clone());
-	renderer.GetCurrentScene()->AppendScene(cubeScene->Clone());
+	//renderer.GetCurrentScene()->AppendScene(mountainScene->Clone());
+	//renderer.GetCurrentScene()->AppendScene(cubeScene->Clone());
     //renderer.GetCurrentScene()->AppendScene(*tigerScene);
 
     //auto root = renderer.GetCurrentScene()->AppendScene(dragonScene->Clone());
 	//root.set<Components::Position>({ 0.0, 3.0, 0.0 });
     
-	for (int i = 0; i < 1; i++) {
+	for (int i = 0; i < 0; i++) {
 		float animationSpeed = randomFloat(0.5, 2.0);
    //     for (auto& object : tigerScene->GetOpaqueRenderableObjectIDMap()) {
 			//object.second->SetAnimationSpeed(animationSpeed);
@@ -343,7 +343,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	}
 
     //renderer.GetCurrentScene()->AppendScene(phoenixScene->Clone());
-    auto root = renderer.GetCurrentScene()->AppendScene(carScene->Clone());
+    //auto root = renderer.GetCurrentScene()->AppendScene(carScene->Clone());
     //renderer.GetCurrentScene()->RemoveEntityByID(root->GetLocalID(), true);
     //renderer.GetCurrentScene()->AppendScene(*cubeScene);
 	//renderer.GetCurrentScene()->AppendScene(bistro);
@@ -409,7 +409,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
  //   auto light3 = renderer.GetCurrentScene()->CreateSpotLightECS(L"light3", XMFLOAT3(0, 1, 3), XMFLOAT3(1, 1, 1), 10.0, {0, -1, 0}, .5, .8, 0.0, 0.0, 1.0);
     auto light1 = renderer.GetCurrentScene()->CreatePointLightECS(L"light1", XMFLOAT3(0, 1, 3), XMFLOAT3(1, 1, 1), 1.0, 0.0, 0.0, 1.0);
     
-    for (int i = 0; i < 1500; i++) {
+    for (int i = 0; i < 0; i++) {
 		auto point = getRandomPointInVolume(-20, 20, -2, 0, -20, 20);
 		auto color = XMFLOAT3(randomFloat(0.0, 1.0), randomFloat(0.0, 1.0), randomFloat(0.0, 1.0));
         auto light1 = renderer.GetCurrentScene()->CreatePointLightECS(L"light"+std::to_wstring(i), XMFLOAT3(point.x, point.y, point.z), color, 3.0, 0.0, 0.0, 1.0, false);

--- a/BasicRenderer/src/Managers/MeshManager.cpp
+++ b/BasicRenderer/src/Managers/MeshManager.cpp
@@ -20,7 +20,7 @@ MeshManager::MeshManager() {
 	m_resourceGroup->AddResource(m_meshletIndices);
 	m_resourceGroup->AddResource(m_meshletTriangles);
 
-	m_perMeshBuffers = resourceManager.CreateIndexedDynamicBuffer(sizeof(PerMeshCB), 1, ResourceState::ALL_SRV, L"OpaquePerMeshBuffers");//resourceManager.CreateIndexedLazyDynamicStructuredBuffer<PerMeshCB>(ResourceState::ALL_SRV, 1, L"perMeshBuffers<PerMeshCB>", 1);
+	m_perMeshBuffers = resourceManager.CreateIndexedDynamicBuffer(sizeof(PerMeshCB), 1, ResourceState::ALL_SRV, L"PerMeshBuffers");//resourceManager.CreateIndexedLazyDynamicStructuredBuffer<PerMeshCB>(ResourceState::ALL_SRV, 1, L"perMeshBuffers<PerMeshCB>", 1);
 	
 	m_perMeshInstanceBuffers = resourceManager.CreateIndexedDynamicBuffer(sizeof(PerMeshCB), 1, ResourceState::ALL_SRV, L"perMeshInstanceBuffers");//resourceManager.CreateIndexedLazyDynamicStructuredBuffer<PerMeshCB>(ResourceState::ALL_SRV, 1, L"perMeshBuffers<PerMeshCB>", 1);
 }
@@ -64,6 +64,7 @@ void MeshManager::AddMesh(std::shared_ptr<Mesh>& mesh, MaterialBuckets bucket, b
 	mesh->SetPerMeshBufferView(std::move(perMeshBufferView));
 
 	mesh->SetBufferViews(std::move(preSkinningView), std::move(postSkinningView), std::move(meshletOffsetsView), std::move(meshletIndicesView), std::move(meshletTrianglesView));
+	mesh->UpdateVertexCount(useMeshletReorderedVertices);
 }
 
 void MeshManager::RemoveMesh(Mesh* mesh) {

--- a/BasicRenderer/src/Managers/ObjectManager.cpp
+++ b/BasicRenderer/src/Managers/ObjectManager.cpp
@@ -19,7 +19,7 @@ ObjectManager::ObjectManager() {
 	m_activeAlphaTestDrawSetIndices = resourceManager.CreateIndexedSortedUnsignedIntBuffer(ResourceState::ALL_SRV, 1, L"activeAlphaTestDrawSetIndices");
 	m_activeBlendDrawSetIndices = resourceManager.CreateIndexedSortedUnsignedIntBuffer(ResourceState::ALL_SRV, 1, L"activeBlendDrawSetIndices");
 }
-Components::ObjectDrawInfo ObjectManager::AddObject(PerObjectCB& perObjectCB, const Components::OpaqueMeshInstances* opaqueInstances, const Components::AlphaTestMeshInstances* alphaTestInstances, const Components::BlendMeshInstances* blendInstances) {
+Components::ObjectDrawInfo ObjectManager::AddObject(const PerObjectCB& perObjectCB, const Components::OpaqueMeshInstances* opaqueInstances, const Components::AlphaTestMeshInstances* alphaTestInstances, const Components::BlendMeshInstances* blendInstances) {
 	
 	Components::ObjectDrawInfo drawInfo;
 

--- a/BasicRenderer/src/Managers/Singletons/PSOManager.cpp
+++ b/BasicRenderer/src/Managers/Singletons/PSOManager.cpp
@@ -467,7 +467,7 @@ void PSOManager::CompileShader(const std::wstring& filename, const std::wstring&
 
 void PSOManager::createRootSignature() {
     // Root parameters
-    D3D12_ROOT_PARAMETER1 parameters[8] = {};
+    D3D12_ROOT_PARAMETER1 parameters[9] = {};
 
     // PerObject buffer index
     parameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
@@ -524,6 +524,13 @@ void PSOManager::createRootSignature() {
 	parameters[7].Constants.RegisterSpace = 0;
 	parameters[7].Constants.Num32BitValues = NumLightClusterRootConstants;
 	parameters[7].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
+	parameters[8].ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
+	parameters[8].Constants.ShaderRegister = 9;
+	parameters[8].Constants.RegisterSpace = 0;
+	parameters[8].Constants.Num32BitValues = NumMiscRootConstants;
+	parameters[8].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
 
     // Root Signature Description
     D3D12_ROOT_SIGNATURE_DESC1 rootSignatureDesc = {};

--- a/BasicRenderer/src/Mesh/Mesh.cpp
+++ b/BasicRenderer/src/Mesh/Mesh.cpp
@@ -254,3 +254,10 @@ void Mesh::SetBaseSkin(std::shared_ptr<Skeleton> skeleton) {
 	}
 	//skeleton->userIDs.push_back(localID);
 }
+
+void Mesh::UpdateVertexCount(bool meshletReorderedVertices) {
+	m_perMeshBufferData.numVertices = meshletReorderedVertices ? m_meshletReorderedVertices.size() / m_perMeshBufferData.vertexByteSize : m_vertices->size() / m_perMeshBufferData.vertexByteSize;
+	if (m_pCurrentMeshManager != nullptr) {
+		m_pCurrentMeshManager->UpdatePerMeshBuffer(m_perMeshBufferView, m_perMeshBufferData);
+	}
+}

--- a/BasicRenderer/src/Mesh/MeshInstance.cpp
+++ b/BasicRenderer/src/Mesh/MeshInstance.cpp
@@ -7,16 +7,23 @@ BufferView* MeshInstance::GetPostSkinningVertexBufferView() {
 
 void MeshInstance::SetBufferViews(std::unique_ptr<BufferView> postSkinningVertexBufferView, std::unique_ptr<BufferView> perMeshInstanceBufferView) {
 	m_postSkinningVertexBufferView = std::move(postSkinningVertexBufferView);
-	m_perMeshInstanceBufferData.postSkinningVertexBufferOffset = m_postSkinningVertexBufferView->GetOffset();
 	m_perMeshInstanceBufferView = std::move(perMeshInstanceBufferView);
+	if (m_postSkinningVertexBufferView == nullptr) {
+		return; // no need to update
+	}
+	m_perMeshInstanceBufferData.postSkinningVertexBufferOffset = m_postSkinningVertexBufferView->GetOffset();
 	if (m_pCurrentMeshManager != nullptr) {
 		m_pCurrentMeshManager->UpdatePerMeshInstanceBuffer(m_perMeshInstanceBufferView, m_perMeshInstanceBufferData);
 	}
 }
 
 void MeshInstance::SetBufferViewUsingBaseMesh(std::unique_ptr<BufferView> perMeshInstanceBufferView) {
-	m_perMeshInstanceBufferData.postSkinningVertexBufferOffset = m_mesh->GetPostSkinningVertexBufferView()->GetOffset();
 	m_perMeshInstanceBufferView = std::move(perMeshInstanceBufferView);
+	auto postSkinningView = m_mesh->GetPostSkinningVertexBufferView();
+	if (postSkinningView == nullptr || m_perMeshInstanceBufferView == nullptr) {
+		return; // no need to update
+	}
+	m_perMeshInstanceBufferData.postSkinningVertexBufferOffset = postSkinningView->GetOffset();
 	if (m_pCurrentMeshManager != nullptr) {
 		m_pCurrentMeshManager->UpdatePerMeshInstanceBuffer(m_perMeshInstanceBufferView, m_perMeshInstanceBufferData);
 	}

--- a/BasicRenderer/src/Scene/Scene.cpp
+++ b/BasicRenderer/src/Scene/Scene.cpp
@@ -27,6 +27,7 @@ Scene::Scene(){
     getNumDirectionalLightCascades = SettingsManager::GetInstance().getSettingGetter<uint8_t>("numDirectionalLightCascades");
     getMaxShadowDistance = SettingsManager::GetInstance().getSettingGetter<float>("maxShadowDistance");
     setDirectionalLightCascadeSplits = SettingsManager::GetInstance().getSettingSetter<std::vector<float>>("directionalLightCascadeSplits");
+	getMeshShadersEnabled = SettingsManager::GetInstance().getSettingGetter<bool>("enableMeshShader");
 
     //Initialize ECS scene
     auto& world = ECSManager::GetInstance().GetWorld();
@@ -148,14 +149,16 @@ void Scene::ActivateRenderable(flecs::entity& entity) {
 	auto globalMeshLibrary = world.get_mut<Components::GlobalMeshLibrary>();
 	auto drawStats = world.get_mut<Components::DrawStats>();
 
+	bool useMeshletReorderedVertices = getMeshShadersEnabled();
+
 	if (opaqueMeshInstances) {
 		//e.add<Components::OpaqueMeshInstances>(drawInfo.opaque.value());
 		for (auto& meshInstance : opaqueMeshInstances->meshInstances) {
 			if (!globalMeshLibrary->meshes.contains(meshInstance->GetMesh()->GetGlobalID())) {
 				globalMeshLibrary->meshes[meshInstance->GetMesh()->GetGlobalID()] = meshInstance->GetMesh();
-				m_managerInterface.GetMeshManager()->AddMesh(meshInstance->GetMesh(), MaterialBuckets::Opaque);
+				m_managerInterface.GetMeshManager()->AddMesh(meshInstance->GetMesh(), MaterialBuckets::Opaque, useMeshletReorderedVertices);
 			}
-			m_managerInterface.GetMeshManager()->AddMeshInstance(meshInstance.get());
+			m_managerInterface.GetMeshManager()->AddMeshInstance(meshInstance.get(), useMeshletReorderedVertices);
 		}
 		drawStats->numOpaqueDraws += opaqueMeshInstances->meshInstances.size();
 		drawStats->numDrawsInScene += opaqueMeshInstances->meshInstances.size();
@@ -165,9 +168,9 @@ void Scene::ActivateRenderable(flecs::entity& entity) {
 		for (auto& meshInstance : alphaTestMeshInstances->meshInstances) {
 			if (!globalMeshLibrary->meshes.contains(meshInstance->GetMesh()->GetGlobalID())) {
 				globalMeshLibrary->meshes[meshInstance->GetMesh()->GetGlobalID()] = meshInstance->GetMesh();
-				m_managerInterface.GetMeshManager()->AddMesh(meshInstance->GetMesh(), MaterialBuckets::AlphaTest);
+				m_managerInterface.GetMeshManager()->AddMesh(meshInstance->GetMesh(), MaterialBuckets::AlphaTest, useMeshletReorderedVertices);
 			}
-			m_managerInterface.GetMeshManager()->AddMeshInstance(meshInstance.get());
+			m_managerInterface.GetMeshManager()->AddMeshInstance(meshInstance.get(), useMeshletReorderedVertices);
 		}
 		drawStats->numAlphaTestDraws += alphaTestMeshInstances->meshInstances.size();
 		drawStats->numDrawsInScene += alphaTestMeshInstances->meshInstances.size();
@@ -177,9 +180,9 @@ void Scene::ActivateRenderable(flecs::entity& entity) {
 		for (auto& meshInstance : blendMeshInstances->meshInstances) {
 			if (!globalMeshLibrary->meshes.contains(meshInstance->GetMesh()->GetGlobalID())) {
 				globalMeshLibrary->meshes[meshInstance->GetMesh()->GetGlobalID()] = meshInstance->GetMesh();
-				m_managerInterface.GetMeshManager()->AddMesh(meshInstance->GetMesh(), MaterialBuckets::Blend);
+				m_managerInterface.GetMeshManager()->AddMesh(meshInstance->GetMesh(), MaterialBuckets::Blend, useMeshletReorderedVertices);
 			}
-			m_managerInterface.GetMeshManager()->AddMeshInstance(meshInstance.get());
+			m_managerInterface.GetMeshManager()->AddMeshInstance(meshInstance.get(), useMeshletReorderedVertices);
 		}
 		drawStats->numBlendDraws += blendMeshInstances->meshInstances.size();
 		drawStats->numDrawsInScene += blendMeshInstances->meshInstances.size();

--- a/BasicRenderer/src/Utilities/Utilities.cpp
+++ b/BasicRenderer/src/Utilities/Utilities.cpp
@@ -75,7 +75,12 @@ std::shared_ptr<Mesh> MeshFromData(const MeshData& meshData, std::wstring name) 
         }
     }
 
-    return Mesh::CreateShared(std::move(rawData), vertexSize, std::move(skinningData), skinningVertexSize, meshData.indices, meshData.material, meshData.flags);
+    std::optional<std::unique_ptr<std::vector<std::byte>>> skinningVertices;
+	if (hasJoints) {
+		skinningVertices = std::move(skinningData);
+	}
+
+    return Mesh::CreateShared(std::move(rawData), vertexSize, std::move(skinningVertices), skinningVertexSize, meshData.indices, meshData.material, meshData.flags);
 }
 
 XMMATRIX RemoveScalingFromMatrix(XMMATRIX& initialMatrix) {


### PR DESCRIPTION
Create reordered vertex buffers for mesh shaders, instead of indexing into original vertex buffer, for less indirection and better cache locality