### PR TITLE
Fix indirect command resource groups (#30)

### DIFF
--- a/BasicRenderer/include/Render/RenderGraphBuildHelper.h
+++ b/BasicRenderer/include/Render/RenderGraphBuildHelper.h
@@ -82,7 +82,7 @@ void BuildOcclusionCullingPipeline(RenderGraph* graph) {
 	bool deferredRendering = SettingsManager::GetInstance().getSettingGetter<bool>("enableDeferredRendering")();
 
     graph->BuildRenderPass("ClearLastFrameIndirectDrawUAVsPass") // Clears indirect draws from last frame
-        .Build<ClearIndirectDrawCommandUAVsPass>(true);
+        .Build<ClearIndirectDrawCommandUAVsPass>(false);
 
     graph->BuildRenderPass("ClearMeshletCullingCommandUAVsPass0") // Clear meshlet culling reset command buffers from last frame
         .Build<ClearMeshletCullingCommandUAVsPass>();
@@ -142,7 +142,7 @@ void BuildGeneralCullingPipeline(RenderGraph* graph) {
 	bool meshletCulling = SettingsManager::GetInstance().getSettingGetter<bool>("enableMeshletCulling")();
 
     graph->BuildRenderPass("ClearOccludersIndirectDrawUAVsPass") // Clear command lists after occluders are drawn
-        .Build<ClearIndirectDrawCommandUAVsPass>(false);
+        .Build<ClearIndirectDrawCommandUAVsPass>(true);
 
     graph->BuildRenderPass("ClearMeshletCullingCommandUAVsPass1") // Clear meshlet culling reset command buffers from prepass
         .Build<ClearMeshletCullingCommandUAVsPass>();

--- a/BasicRenderer/include/RenderPasses/Base/ComputePass.h
+++ b/BasicRenderer/include/RenderPasses/Base/ComputePass.h
@@ -32,6 +32,8 @@ public:
 	virtual ~ComputePass() = default;
 
 	virtual void Setup(const ResourceRegistryView& resourceRegistryView) = 0;
+	virtual void RegisterCommandLists(std::vector<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList7>> commandLists) {};
+
 	virtual void Update() {};
 	virtual PassReturn Execute(RenderContext& context) = 0;
 	virtual void Cleanup(RenderContext& context) = 0;

--- a/BasicRenderer/include/RenderPasses/Base/RenderPass.h
+++ b/BasicRenderer/include/RenderPasses/Base/RenderPass.h
@@ -38,7 +38,9 @@ public:
     virtual ~RenderPass() = default;
 
     virtual void Setup(const ResourceRegistryView& resourceRegistryView) = 0;
-	virtual void Update() {};
+	  virtual void RegisterCommandLists(std::vector<Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList7>> commandLists) {};
+
+	  virtual void Update() {};
     virtual PassReturn Execute(RenderContext& context) = 0;
     virtual void Cleanup(RenderContext& context) = 0;
 

--- a/BasicRenderer/include/RenderPasses/ClearUAVsPass.h
+++ b/BasicRenderer/include/RenderPasses/ClearUAVsPass.h
@@ -18,12 +18,13 @@ public:
 	ClearIndirectDrawCommandUAVsPass(bool clearBlend) : m_clearBlend(clearBlend) {}
 
 	void DeclareResourceUsages(RenderPassBuilder* builder) override {
-		builder->WithCopyDest(Builtin::IndirectCommandBuffers::Opaque, Builtin::IndirectCommandBuffers::AlphaTest);
+		builder->WithCopyDest(Builtin::IndirectCommandBuffers::Opaque, 
+			Builtin::IndirectCommandBuffers::AlphaTest);
 		if (m_clearBlend) {
 			builder->WithCopyDest(Builtin::IndirectCommandBuffers::Blend);
 		}
 	}
-
+  
 	void Setup(const ResourceRegistryView& resourceRegistryView) override {
 		auto& ecsWorld = ECSManager::GetInstance().GetWorld();
 		lightQuery = ecsWorld.query_builder<Components::LightViewInfo>().cached().cache_kind(flecs::QueryCacheAll).build();
@@ -47,18 +48,18 @@ public:
 
 		// Opaque buffer
 		for (auto& child : m_opaqueIndirectCommandBuffer->GetChildren()) {
-			std::shared_ptr<Buffer> resource = std::dynamic_pointer_cast<Buffer>(child);
+			std::shared_ptr<DynamicGloballyIndexedResource> resource = std::dynamic_pointer_cast<DynamicGloballyIndexedResource>(child);
 			if (!resource) continue;
-			auto counterOffset = resource->GetUAVCounterOffset();
+			auto counterOffset = resource->GetResource()->GetUAVCounterOffset();
 			auto apiResource = resource->GetAPIResource();
 			commandList->CopyBufferRegion(apiResource, counterOffset, counterReset, 0, sizeof(UINT));
 		}
 
 		// Alpha test buffer
 		for (auto& child : m_alphaTestIndirectCommandBuffer->GetChildren()) {
-			std::shared_ptr<Buffer> resource = std::dynamic_pointer_cast<Buffer>(child);
+			std::shared_ptr<DynamicGloballyIndexedResource> resource = std::dynamic_pointer_cast<DynamicGloballyIndexedResource>(child);
 			if (!resource) continue;
-			auto counterOffset = resource->GetUAVCounterOffset();
+			auto counterOffset = resource->GetResource()->GetUAVCounterOffset();
 			auto apiResource = resource->GetAPIResource();
 			commandList->CopyBufferRegion(apiResource, counterOffset, counterReset, 0, sizeof(UINT));
 		}
@@ -66,9 +67,9 @@ public:
 		// Blend buffer
 		if (!m_clearBlend) return {};
 		for (auto& child : m_blendIndirectCommandBuffer->GetChildren()) {
-			std::shared_ptr<Buffer> resource = std::dynamic_pointer_cast<Buffer>(child);
+			std::shared_ptr<DynamicGloballyIndexedResource> resource = std::dynamic_pointer_cast<DynamicGloballyIndexedResource>(child);
 			if (!resource) continue;
-			auto counterOffset = resource->GetUAVCounterOffset();
+			auto counterOffset = resource->GetResource()->GetUAVCounterOffset();
 			auto apiResource = resource->GetAPIResource();
 			commandList->CopyBufferRegion(apiResource, counterOffset, counterReset, 0, sizeof(UINT));
 		}
@@ -118,9 +119,9 @@ public:
 
 		// Meshlet frustrum culling buffer
 		for (auto& child : m_meshletCullingCommandBuffers->GetChildren()) {
-			std::shared_ptr<Buffer> resource = std::dynamic_pointer_cast<Buffer>(child);
+			std::shared_ptr<DynamicGloballyIndexedResource> resource = std::dynamic_pointer_cast<DynamicGloballyIndexedResource>(child);
 			if (!resource) continue;
-			auto counterOffset = resource->GetUAVCounterOffset();
+			auto counterOffset = resource->GetResource()->GetUAVCounterOffset();
 			auto apiResource = resource->GetAPIResource();
 			commandList->CopyBufferRegion(apiResource, counterOffset, counterReset, 0, sizeof(UINT));
 		}

--- a/BasicRenderer/src/Managers/IndirectCommandBufferManager.cpp
+++ b/BasicRenderer/src/Managers/IndirectCommandBufferManager.cpp
@@ -58,32 +58,32 @@ Components::IndirectCommandBuffers IndirectCommandBufferManager::CreateBuffersFo
     auto opaqueBuffer = ResourceManager::GetInstance().CreateIndexedStructuredBuffer(m_opaqueCommandBufferSize, sizeof(DispatchMeshIndirectCommand), false, true, true);
     opaqueBuffer->SetName(L"OpaqueIndirectCommandBuffer ("+std::to_wstring(viewID)+L")");
     std::shared_ptr<DynamicGloballyIndexedResource> pOpaqueDynamicResource = std::make_shared<DynamicGloballyIndexedResource>(opaqueBuffer);
-	m_opaqueResourceGroup->AddResource(opaqueBuffer);
+	m_opaqueResourceGroup->AddResource(pOpaqueDynamicResource);
 
 	auto alphaTestBuffer = ResourceManager::GetInstance().CreateIndexedStructuredBuffer(m_alphaTestCommandBufferSize, sizeof(DispatchMeshIndirectCommand), false, true, true);
 	alphaTestBuffer->SetName(L"AlphaTestIndirectCommandBuffer (" + std::to_wstring(viewID) + L")");
 	std::shared_ptr<DynamicGloballyIndexedResource> pAlphaTestDynamicResource = std::make_shared<DynamicGloballyIndexedResource>(alphaTestBuffer);
-	m_alphaTestResourceGroup->AddResource(alphaTestBuffer);
+	m_alphaTestResourceGroup->AddResource(pAlphaTestDynamicResource);
 
 	auto blendBuffer = ResourceManager::GetInstance().CreateIndexedStructuredBuffer(m_blendCommandBufferSize, sizeof(DispatchMeshIndirectCommand), false, true, true);
 	blendBuffer->SetName(L"BlendIndirectCommandBuffer (" + std::to_wstring(viewID) + L")");
 	std::shared_ptr<DynamicGloballyIndexedResource> pBlendDynamicResource = std::make_shared<DynamicGloballyIndexedResource>(blendBuffer);
-	m_blendResourceGroup->AddResource(blendBuffer);
+	m_blendResourceGroup->AddResource(pBlendDynamicResource);
 
 	auto meshletFrustrumCullingBuffer = ResourceManager::GetInstance().CreateIndexedStructuredBuffer(m_totalIndirectCommands, sizeof(DispatchIndirectCommand), false, true, true);
 	meshletFrustrumCullingBuffer->SetName(L"MeshletFrustrumCullingIndirectCommandBuffer (" + std::to_wstring(viewID) + L")");
 	std::shared_ptr<DynamicGloballyIndexedResource> pMeshletFrustrumCullingDynamicResource = std::make_shared<DynamicGloballyIndexedResource>(meshletFrustrumCullingBuffer);
-	m_meshletCullingCommandResourceGroup->AddResource(meshletFrustrumCullingBuffer);
+	m_meshletCullingCommandResourceGroup->AddResource(pMeshletFrustrumCullingDynamicResource);
 
 	auto meshletOcclusionCullingBuffer = ResourceManager::GetInstance().CreateIndexedStructuredBuffer(m_totalIndirectCommands, sizeof(DispatchIndirectCommand), false, true, true);
 	meshletOcclusionCullingBuffer->SetName(L"MeshletOcclusionCullingIndirectCommandBuffer (" + std::to_wstring(viewID) + L")");
 	std::shared_ptr<DynamicGloballyIndexedResource> pMeshletOcclusionCullingDynamicResource = std::make_shared<DynamicGloballyIndexedResource>(meshletOcclusionCullingBuffer);
-	m_meshletCullingCommandResourceGroup->AddResource(meshletOcclusionCullingBuffer);
+	m_meshletCullingCommandResourceGroup->AddResource(pMeshletOcclusionCullingDynamicResource);
 
 	auto meshletCullingResetBuffer = ResourceManager::GetInstance().CreateIndexedStructuredBuffer(m_totalIndirectCommands, sizeof(DispatchIndirectCommand), false, true, true);
 	meshletCullingResetBuffer->SetName(L"MeshletCullingResetIndirectCommandBuffer (" + std::to_wstring(viewID) + L")");
 	std::shared_ptr<DynamicGloballyIndexedResource> pMeshletFrustrumCullingResetDynamicResource = std::make_shared<DynamicGloballyIndexedResource>(meshletCullingResetBuffer);
-	m_meshletCullingCommandResourceGroup->AddResource(meshletCullingResetBuffer);
+	m_meshletCullingCommandResourceGroup->AddResource(pMeshletFrustrumCullingResetDynamicResource);
 
     Components::IndirectCommandBuffers bufferComponent;
 	bufferComponent.opaqueIndirectCommandBuffer = pOpaqueDynamicResource;


### PR DESCRIPTION
* combine RenderGraphBuilder and RenderGraph, start DLSS

* contd.

* Resource registry to start pass resource use cleanup

* start move to string representation for resource identifiers, with code gen

* contd.

* contd.

* contd.

* contd.

* contd.

* first launching

* contd.

* move declarations to passes

* pull hdr target and depth out of render context

* fix indirect command resource group membership